### PR TITLE
Refactor to tf_utils in train.ipynb and flow_single.py

### DIFF
--- a/flow_single.py
+++ b/flow_single.py
@@ -4,8 +4,10 @@ from metaflow import (
     step,
     batch,
     conda_base,
-    tensorflow_parallel,
+    tensorflow_parallel
 )
+
+from tf_utils import TFMixin
 
 # from dotenv import load_dotenv
 # try:
@@ -24,31 +26,54 @@ from metaflow import (
 #     },
 #     python="3.9.16",
 # )
+class T5TensorFlowFlow(FlowSpec, TFMixin):
 
-class T5TensorFlowFlow(FlowSpec):
     num_parallel = Parameter(
         name="num_parallel",
         default=2,
+        type=int
     )
 
     batch_size = Parameter(
         name="batch_size",
         default=4,
+        type=int
     )
 
     epochs = Parameter(
         name="epochs",
         default=1,
+        type=int
     )
 
     tensorboard_logdir = Parameter(
         name="tensorboard_logdir", 
         default="./data/experiments/t5/logs",
+        type=str
     )
 
     checkpoint_savedir = Parameter(
         name="checkpoint_savedir",
         default="./data/experiments/t5/models",
+        type=str
+    )
+
+    model_arch = Parameter(
+        name="model_arch",
+        default="SnapthatT5", # add/view options in utils.py
+        type=str
+    )
+
+    model_src = Parameter(
+        name = "model_src",
+        default = "t5-small",
+        type=str
+    )
+
+    learning_rate = Parameter(
+        name = "learning_rate",
+        default=1e-6,
+        type=float
     )
 
     @step
@@ -56,95 +81,18 @@ class T5TensorFlowFlow(FlowSpec):
         print("start")
         self.next(self.train)
 
-    # @step
-#     def load_data(self):
-#         print("load data")
-#         from datasets import load_dataset
-#         from dataset_helper import encode, to_tf_dataset
-
-#         train_dataset = load_dataset('squad', split='train[:10%]')
-#         # valid_dataset = load_dataset('squad', split='validation')
-#         print("load done")
-#         print("dataset feature: ", train_dataset.features)
-
-#         train_ds = train_dataset.map(encode)
-#         # valid_ds = valid_dataset.map(encode)
-#         # ex = next(iter(train_ds))
-#         # print("Example data from the mapped dataset: \n")
-#         # for e in ex:
-#         #     print(e, type(ex[e]), ex[e])
-
-#         print("encode done")
-
-#         self.train_ds = train_ds
-
-        # self.tf_train_ds = to_tf_dataset(train_ds)
-        # self.tf_valid_ds = to_tf_dataset(valid_ds)
-        # print("to_tf_dataset done")
-
-        # self.tf_train_ds = create_dataset(tf_train_ds, batch_size=self.batch_size, shuffling=True)
-        # self.tf_valid_ds = create_dataset(tf_valid_ds, batch_size=self.batch_size, shuffling=False)
-
-    
     # @batch(cpu=4, gpu=3, queue="metaflow-gpu-fusmltrn")
     # @tensorflow_parallel
     @step
     def train(self):
-        import os
-        import json
-        import datetime
-        import numpy as np
-        import tensorflow as tf
-        from scheduler import CustomSchedule
-        from model import SnapthatT5
-        from dataset_helper import create_dataset
         
-        from datasets import load_dataset
-        from dataset_helper import encode, to_tf_dataset
-        
-        train_dataset = load_dataset('squad', split='train[:10%]')
-        valid_dataset = load_dataset('squad', split='validation[:10%]')
-        print("load done")
-        print("dataset feature: ", train_dataset.features)
+        tf_train_ds, tf_valid_ds, train_steps, valid_steps = self.get_data(
+            'squad', pct='10', batch_size = self.batch_size, num_workers=1)
 
-        train_ds = train_dataset.map(encode)
-        valid_ds = valid_dataset.map(encode)
-        tf_train_ds = to_tf_dataset(train_ds)
-        tf_valid_ds = to_tf_dataset(valid_ds)
-        print("to_tf_dataset done")
+        callbacks = self.configure_callbacks(self.tensorboard_logdir, self.checkpoint_savedir)
 
-        # tf_config = json.loads(os.environ["TF_CONFIG"])
-        # num_workers = len(tf_config["cluster"]["worker"])
-        num_workers = 1
-        global_batch_size = num_workers * self.batch_size
-        # strategy = tf.distribute.MultiWorkerMirroredStrategy()
-
-        train_steps = int(np.ceil(len(train_dataset)/self.batch_size))
-        valid_steps = int(np.ceil(len(valid_dataset)/self.batch_size))
-
-        tf_train_ds = create_dataset(tf_train_ds, batch_size=global_batch_size, shuffling=True)
-        tf_valid_ds = create_dataset(tf_valid_ds, batch_size=global_batch_size, shuffling=False)
-
-        tensorboard_logpath = self.tensorboard_logdir + "/" + datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
-        tensorboard_callback = tf.keras.callbacks.TensorBoard(log_dir=tensorboard_logpath)
-
-        checkpoint_filepath = self.checkpoint_savedir + "/T5-{epoch:04d}-{val_loss:.4f}.ckpt"
-        checkpoint_callback = tf.keras.callbacks.ModelCheckpoint(
-            filepath=checkpoint_filepath,
-            mode='min',
-            save_best_only=True,
-        )
-
-        callbacks = [tensorboard_callback, checkpoint_callback]
-        metrics = [tf.keras.metrics.SparseTopKCategoricalAccuracy(name='accuracy')]
-
-        # learning_rate = CustomSchedule()
-        learning_rate = 1e-6
-
-        # with strategy.scope():
-        optimizer = tf.keras.optimizers.Adam(learning_rate)
-        model = SnapthatT5.from_pretrained("t5-small")
-        model.compile(optimizer=optimizer, metrics=metrics)
+        self.tuning_set = {'learning_rate': self.learning_rate}
+        model = self.compile_model(model_src = self.model_src, hyperparams=self.tuning_set)
 
         print("begin training.")
         model.fit(
@@ -154,8 +102,8 @@ class T5TensorFlowFlow(FlowSpec):
             validation_data=tf_valid_ds, 
             validation_steps=valid_steps,
             callbacks=callbacks, 
+            verbose=2
         )
-
         print("training done.")
 
         self.next(self.end)
@@ -167,7 +115,6 @@ class T5TensorFlowFlow(FlowSpec):
     @step
     def end(self):
         pass
-    
 
 if __name__ == "__main__":
     T5TensorFlowFlow()

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,7 @@
+conda install -c conda-forge cudatoolkit=11.8.0
+python3 -m pip install nvidia-cudnn-cu11==8.6.0.163 tensorflow==2.12.* datasets transformers sentencepiece git+https://github.com/emattia/metaflow.git@4e8baa290e8eac8a0a7e062d923125820cca7e92
+mkdir -p $CONDA_PREFIX/etc/conda/activate.d
+echo 'CUDNN_PATH=$(dirname $(python -c "import nvidia.cudnn;print(nvidia.cudnn.__file__)"))' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CONDA_PREFIX/lib/:$CUDNN_PATH/lib' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+source $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+python3 -c "import tensorflow as tf; print(tf.config.list_physical_devices('GPU'))"

--- a/tf_utils.py
+++ b/tf_utils.py
@@ -1,0 +1,69 @@
+from datasets import load_dataset
+from dataset_helper import encode, to_tf_dataset
+import numpy as np
+from dataset_helper import create_dataset
+import os
+import json
+import datetime
+import numpy as np
+import tensorflow as tf
+from scheduler import CustomSchedule
+from model import SnapthatT5
+
+MY_METRICS = {
+    'accuracy': tf.keras.metrics.SparseTopKCategoricalAccuracy(name='accuracy')
+}
+
+MY_OPTIMIZERS = {
+    'Adam': tf.keras.optimizers.Adam
+}
+
+MY_MODELS = {
+    'SnapthatT5': SnapthatT5
+}
+
+FIXED_HYPERPARAMS = {
+    'model_arch': 'SnapthatT5', # needs to be in MY_MODELS
+    'optimizer': 'Adam'         # needs to be in MY_OPTIMIZERS
+}
+
+class TFMixin:
+
+    def get_data(self, name, pct, batch_size, num_workers):
+        train_dataset = load_dataset(name, split=f'train[:{pct}%]')
+        valid_dataset = load_dataset(name, split=f'validation[:{pct}%]')
+        train_ds = train_dataset.map(encode)
+        valid_ds = valid_dataset.map(encode)
+        tf_train_ds = to_tf_dataset(train_ds)
+        tf_valid_ds = to_tf_dataset(valid_ds)
+        train_steps = int(np.ceil(len(train_dataset)/batch_size))
+        valid_steps = int(np.ceil(len(valid_dataset)/batch_size))
+        global_batch_size = num_workers * batch_size
+        tf_train_ds = create_dataset(tf_train_ds, batch_size=global_batch_size, shuffling=True)
+        tf_valid_ds = create_dataset(tf_valid_ds, batch_size=global_batch_size, shuffling=False)
+        return tf_train_ds, tf_valid_ds, train_steps, valid_steps
+
+    def configure_callbacks(self, tensorboard_logdir, checkpoint_savedir):
+        tensorboard_logpath = tensorboard_logdir + "/" + datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
+        tensorboard_callback = tf.keras.callbacks.TensorBoard(log_dir=tensorboard_logpath)
+        checkpoint_filepath = checkpoint_savedir + "/T5-{epoch:04d}-{val_loss:.4f}.ckpt"
+        checkpoint_callback = tf.keras.callbacks.ModelCheckpoint(
+            filepath=checkpoint_filepath,
+            mode='min',
+            save_best_only=True,
+        )
+        callbacks = [tensorboard_callback, checkpoint_callback]
+        return callbacks
+
+    def compile_model(
+        self, 
+        model_src="t5-small", 
+        metrics=['accuracy'], 
+        hyperparams={'learning_rate': 1e-6}
+    ):
+        hyperparams |= FIXED_HYPERPARAMS
+        metrics = [MY_METRICS[m] for m in metrics]
+        optimizer = MY_OPTIMIZERS[hyperparams['optimizer']](hyperparams['learning_rate'])
+        model = MY_MODELS[hyperparams['model_arch']].from_pretrained(model_src)
+        model.compile(optimizer=optimizer, metrics=metrics)
+        return model

--- a/train.ipynb
+++ b/train.ipynb
@@ -2,345 +2,73 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/linz1/miniconda3/envs/tf_parallel/lib/python3.9/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
-   "source": [
-    "from datasets import load_dataset\n",
-    "from dataset_helper import encode, to_tf_dataset\n",
-    "import os\n",
-    "import json\n",
-    "import datetime\n",
-    "import tensorflow as tf\n",
-    "from scheduler import CustomSchedule\n",
-    "from model import SnapthatT5\n",
-    "from dataset_helper import create_dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "load data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:datasets.builder:Found cached dataset squad (/Users/linz1/.cache/huggingface/datasets/squad/plain_text/1.0.0/d6ec3ceb99ca480ce37cdd35555d6cb2511d223b9150cce08a837ef62ffea453)\n",
-      "WARNING:datasets.builder:Found cached dataset squad (/Users/linz1/.cache/huggingface/datasets/squad/plain_text/1.0.0/d6ec3ceb99ca480ce37cdd35555d6cb2511d223b9150cce08a837ef62ffea453)\n",
-      "WARNING:datasets.arrow_dataset:Loading cached processed dataset at /Users/linz1/.cache/huggingface/datasets/squad/plain_text/1.0.0/d6ec3ceb99ca480ce37cdd35555d6cb2511d223b9150cce08a837ef62ffea453/cache-2c518737dfa6e3ac.arrow\n",
-      "WARNING:datasets.arrow_dataset:Loading cached processed dataset at /Users/linz1/.cache/huggingface/datasets/squad/plain_text/1.0.0/d6ec3ceb99ca480ce37cdd35555d6cb2511d223b9150cce08a837ef62ffea453/cache-377d7f4e3b1c3e1b.arrow\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "load done\n",
-      "dataset feature:  {'id': Value(dtype='string', id=None), 'title': Value(dtype='string', id=None), 'context': Value(dtype='string', id=None), 'question': Value(dtype='string', id=None), 'answers': Sequence(feature={'text': Value(dtype='string', id=None), 'answer_start': Value(dtype='int32', id=None)}, length=-1, id=None)}\n",
-      "encode done\n",
-      "ds:  <_PrefetchDataset element_spec={'input_ids': TensorSpec(shape=(250,), dtype=tf.int64, name=None), 'attention_mask': TensorSpec(shape=(250,), dtype=tf.int64, name=None), 'labels': TensorSpec(shape=(54,), dtype=tf.int64, name=None), 'decoder_attention_mask': TensorSpec(shape=(54,), dtype=tf.int64, name=None)}>\n",
-      "Example data from the dataset: \n",
-      "\n",
-      "input_ids tf.Tensor(\n",
-      "[ 1525   834   526    10   304  4068   410     8 16823  3790     3 18280\n",
-      "  2385    16   507  3449    16   301  1211  1395  1410    58  2625    10\n",
-      " 30797   120     6     8   496    65     3     9  6502  1848     5    71\n",
-      "  2916     8  5140  5450    31     7  2045 22161    19     3     9  7069\n",
-      " 12647    13     8 16823  3790     5     3 29167    16   851    13     8\n",
-      "  5140  5450    11  5008    34     6    19     3     9  8658 12647    13\n",
-      "  2144    28  6026     3    76 24266    28     8  9503    96   553    15\n",
-      "  7980  1980  1212 13285  1496  1280  3021    12     8  5140  5450    19\n",
-      "     8 23711  2617    13     8     3 24756  6219     5     3 29167  1187\n",
-      "     8 20605  2617    19     8  8554    17   235     6     3     9 17535\n",
-      "   286    13  7029    11  9619     5    94    19     3     9 16455    13\n",
-      "     8     3  3844    17   235    44   301  1211  1395     6  1410   213\n",
-      "     8 16823  3790     3 28285    26   120  4283    12  2788  8942     9\n",
-      "    26  1954   264  8371  8283    16   507  3449     5   486     8   414\n",
-      "    13     8   711  1262    41   232    16     3     9  1223   689    24\n",
-      "  1979     7   190   220 12647     7    11     8  2540 10576    15   201\n",
-      "    19     3     9   650     6   941  3372 12647    13  3790     5     1\n",
-      "     0     0     0     0     0     0     0     0     0     0     0     0\n",
-      "     0     0     0     0     0     0     0     0     0     0     0     0\n",
-      "     0     0     0     0     0     0     0     0     0     0     0     0\n",
-      "     0     0     0     0     0     0     0     0     0     0], shape=(250,), dtype=int64)\n",
-      "<class 'tensorflow.python.framework.ops.EagerTensor'>\n",
-      "attention_mask tf.Tensor(\n",
-      "[1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n",
-      " 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], shape=(250,), dtype=int64)\n",
-      "<class 'tensorflow.python.framework.ops.EagerTensor'>\n",
-      "labels tf.Tensor(\n",
-      "[2788 8942    9   26 1954  264 8371 8283    1    0    0    0    0    0\n",
-      "    0    0    0    0    0    0    0    0    0    0    0    0    0    0\n",
-      "    0    0    0    0    0    0    0    0    0    0    0    0    0    0\n",
-      "    0    0    0    0    0    0    0    0    0    0    0    0], shape=(54,), dtype=int64)\n",
-      "<class 'tensorflow.python.framework.ops.EagerTensor'>\n",
-      "decoder_attention_mask tf.Tensor(\n",
-      "[1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n",
-      " 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], shape=(54,), dtype=int64)\n",
-      "<class 'tensorflow.python.framework.ops.EagerTensor'>\n",
-      "ds:  <_PrefetchDataset element_spec={'input_ids': TensorSpec(shape=(250,), dtype=tf.int64, name=None), 'attention_mask': TensorSpec(shape=(250,), dtype=tf.int64, name=None), 'labels': TensorSpec(shape=(54,), dtype=tf.int64, name=None), 'decoder_attention_mask': TensorSpec(shape=(54,), dtype=tf.int64, name=None)}>\n",
-      "Example data from the dataset: \n",
-      "\n",
-      "input_ids tf.Tensor(\n",
-      "[ 1525   834   526    10  4073 10439   372  7283     8    71  5390    44\n",
-      "  2011  9713   943    58  2625    10  2011  9713   943    47    46   797\n",
-      "  3370   467    12  2082     8  6336    13     8   868 10929  3815    41\n",
-      " 12619   434    61    21     8  1230   774     5    37   797 10929  4379\n",
-      "    41   188  5390    61  6336 12154  4027    29   509     7 17025     8\n",
-      "   868 10929  4379    41   567  5390    61  6336  5089 21149     7   997\n",
-      "   104  1714    12  3807    70  1025  2011  9713  2233     5    37   467\n",
-      "    47  1944    30  2083  7973  5123    44 16755    31     7 12750    16\n",
-      "     8  1051  5901  2474  5690    44  4625  9908     9     6  1826     5\n",
-      "   282    48    47     8   943   189  2011  9713     6     8  5533     3\n",
-      " 25472     8    96 14910    35  7685   121    28   796  2045    18 24186\n",
-      "  6985     6    38   168    38 18223 12547    53     8  4387    13     3\n",
-      " 21990   284  2011  9713   467    28  3385  7507  4900     7    41  7248\n",
-      "    84     8   467   133    43   118   801    38    96 23290  9713   301\n",
-      "  8512     6    78    24     8  3554   228  8304   120  1451     8 19248\n",
-      "  7507  4900     7   943     5     1     0     0     0     0     0     0\n",
-      "     0     0     0     0     0     0     0     0     0     0     0     0\n",
-      "     0     0     0     0     0     0     0     0     0     0     0     0\n",
-      "     0     0     0     0     0     0     0     0     0     0     0     0\n",
-      "     0     0     0     0     0     0     0     0     0     0     0     0\n",
-      "     0     0     0     0     0     0     0     0     0     0], shape=(250,), dtype=int64)\n",
-      "<class 'tensorflow.python.framework.ops.EagerTensor'>\n",
-      "attention_mask tf.Tensor(\n",
-      "[1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n",
-      " 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], shape=(250,), dtype=int64)\n",
-      "<class 'tensorflow.python.framework.ops.EagerTensor'>\n",
-      "labels tf.Tensor(\n",
-      "[12154  4027    29   509     7     6   308    35   624  4027    29   509\n",
-      "     7     6   308    35   624  4027    29   509     7     1     0     0\n",
-      "     0     0     0     0     0     0     0     0     0     0     0     0\n",
-      "     0     0     0     0     0     0     0     0     0     0     0     0\n",
-      "     0     0     0     0     0     0], shape=(54,), dtype=int64)\n",
-      "<class 'tensorflow.python.framework.ops.EagerTensor'>\n",
-      "decoder_attention_mask tf.Tensor(\n",
-      "[1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n",
-      " 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], shape=(54,), dtype=int64)\n",
-      "<class 'tensorflow.python.framework.ops.EagerTensor'>\n",
-      "Example data from the tf dataset: \n",
-      "\n",
-      "input_ids <class 'tensorflow.python.framework.ops.EagerTensor'> tf.Tensor(\n",
-      "[ 1525   834   526    10   304  4068   410     8 16823  3790     3 18280\n",
-      "  2385    16   507  3449    16   301  1211  1395  1410    58  2625    10\n",
-      " 30797   120     6     8   496    65     3     9  6502  1848     5    71\n",
-      "  2916     8  5140  5450    31     7  2045 22161    19     3     9  7069\n",
-      " 12647    13     8 16823  3790     5     3 29167    16   851    13     8\n",
-      "  5140  5450    11  5008    34     6    19     3     9  8658 12647    13\n",
-      "  2144    28  6026     3    76 24266    28     8  9503    96   553    15\n",
-      "  7980  1980  1212 13285  1496  1280  3021    12     8  5140  5450    19\n",
-      "     8 23711  2617    13     8     3 24756  6219     5     3 29167  1187\n",
-      "     8 20605  2617    19     8  8554    17   235     6     3     9 17535\n",
-      "   286    13  7029    11  9619     5    94    19     3     9 16455    13\n",
-      "     8     3  3844    17   235    44   301  1211  1395     6  1410   213\n",
-      "     8 16823  3790     3 28285    26   120  4283    12  2788  8942     9\n",
-      "    26  1954   264  8371  8283    16   507  3449     5   486     8   414\n",
-      "    13     8   711  1262    41   232    16     3     9  1223   689    24\n",
-      "  1979     7   190   220 12647     7    11     8  2540 10576    15   201\n",
-      "    19     3     9   650     6   941  3372 12647    13  3790     5     1\n",
-      "     0     0     0     0     0     0     0     0     0     0     0     0\n",
-      "     0     0     0     0     0     0     0     0     0     0     0     0\n",
-      "     0     0     0     0     0     0     0     0     0     0     0     0\n",
-      "     0     0     0     0     0     0     0     0     0     0], shape=(250,), dtype=int64)\n",
-      "attention_mask <class 'tensorflow.python.framework.ops.EagerTensor'> tf.Tensor(\n",
-      "[1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n",
-      " 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n",
-      " 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], shape=(250,), dtype=int64)\n",
-      "labels <class 'tensorflow.python.framework.ops.EagerTensor'> tf.Tensor(\n",
-      "[2788 8942    9   26 1954  264 8371 8283    1    0    0    0    0    0\n",
-      "    0    0    0    0    0    0    0    0    0    0    0    0    0    0\n",
-      "    0    0    0    0    0    0    0    0    0    0    0    0    0    0\n",
-      "    0    0    0    0    0    0    0    0    0    0    0    0], shape=(54,), dtype=int64)\n",
-      "decoder_attention_mask <class 'tensorflow.python.framework.ops.EagerTensor'> tf.Tensor(\n",
-      "[1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n",
-      " 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], shape=(54,), dtype=int64)\n",
-      "to_tf_dataset done\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"load data\")\n",
-    "\n",
-    "train_dataset = load_dataset('squad', split='train[:10%]')\n",
-    "valid_dataset = load_dataset('squad', split='validation[:10%]')\n",
-    "print(\"load done\")\n",
-    "print(\"dataset feature: \", train_dataset.features)\n",
-    "\n",
-    "train_ds = train_dataset.map(encode)\n",
-    "valid_ds = valid_dataset.map(encode)\n",
-    "# ex = next(iter(train_ds))\n",
-    "# print(\"Example data from the mapped dataset: \\n\")\n",
-    "# for e in ex:\n",
-    "#     print(e, type(ex[e]), ex[e])\n",
-    "print(\"encode done\")\n",
-    "\n",
-    "tf_train_ds = to_tf_dataset(train_ds)\n",
-    "tf_valid_ds = to_tf_dataset(valid_ds)\n",
-    "\n",
-    "ex = next(iter(tf_train_ds))\n",
-    "print(\"Example data from the tf dataset: \\n\")\n",
-    "for e in ex:\n",
-    "    print(e, type(ex[e]), ex[e])\n",
-    "\n",
-    "print(\"to_tf_dataset done\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "tensorboard_logdir = \"./data/experiments/t5/logs\"\n",
-    "checkpoint_savedir = \"./data/experiments/t5/models\"\n",
-    "\n",
-    "batch_size = 4\n",
-    "train_steps = int(np.ceil(len(train_dataset)/batch_size))\n",
-    "valid_steps = int(np.ceil(len(valid_dataset)/batch_size))\n",
-    "\n",
-    "# os.environ[\"TF_CONFIG\"] = json.dumps({\n",
-    "#     \"cluster\": {\n",
-    "#         \"worker\": [\"host1:port\", \"host2:port\"],\n",
-    "#         \"ps\": [\"host4:port\", \"host5:port\"]\n",
-    "#     },\n",
-    "#    \"task\": {\"type\": \"worker\", \"index\": 1}\n",
-    "# })"
+    "from tf_utils import TFMixin"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Using MirroredStrategy with devices ('/job:localhost/replica:0/task:0/device:GPU:0',)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Using MirroredStrategy with devices ('/job:localhost/replica:0/task:0/device:GPU:0',)\n",
-      "WARNING:absl:At this time, the v2.11+ optimizer `tf.keras.optimizers.Adam` runs slowly on M1/M2 Macs, please use the legacy Keras optimizer instead, located at `tf.keras.optimizers.legacy.Adam`.\n",
-      "All PyTorch model weights were used when initializing SnapthatT5.\n",
-      "\n",
-      "Some weights or buffers of the TF 2.0 model SnapthatT5 were not initialized from the PyTorch model and are newly initialized: ['total', 'count']\n",
-      "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n",
-      "WARNING:absl:There is a known slowdown when using v2.11+ Keras optimizers on M1/M2 Macs. Falling back to the legacy Keras optimizer, i.e., `tf.keras.optimizers.legacy.Adam`.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2190/2190 [==============================] - ETA: 0s - accuracy: 0.6316 - loss: 4.9978 - lr: 1.0000e-06"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:absl:Found untraced functions such as final_layer_norm_layer_call_fn, final_layer_norm_layer_call_and_return_conditional_losses, dropout_86_layer_call_fn, dropout_86_layer_call_and_return_conditional_losses, final_layer_norm_layer_call_fn while saving (showing 5 of 524). These functions will not be directly callable after loading.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Assets written to: ./data/experiments/t5/models/T5-0001-1.2095.ckpt/assets\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Assets written to: ./data/experiments/t5/models/T5-0001-1.2095.ckpt/assets\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2190/2190 [==============================] - 854s 383ms/step - accuracy: 0.6316 - loss: 4.9978 - lr: 1.0000e-06 - val_accuracy: 0.9146 - val_loss: 1.2095\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<keras.callbacks.History at 0x3b46b7370>"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# tf_config = json.loads(os.environ[\"TF_CONFIG\"])\n",
-    "# num_workers = len(tf_config[\"cluster\"][\"worker\"])\n",
-    "# global_batch_size = num_workers * 4\n",
-    "global_batch_size = batch_size\n",
-    "# strategy = tf.distribute.MultiWorkerMirroredStrategy()\n",
-    "strategy = tf.distribute.MirroredStrategy()\n",
+    "# config\n",
+    "tensorboard_logdir = \"./data/experiments/t5/logs\"\n",
+    "checkpoint_savedir = \"./data/experiments/t5/models\"\n",
     "\n",
-    "tf_train_ds = create_dataset(tf_train_ds, batch_size=global_batch_size, shuffling=True)\n",
-    "tf_valid_ds = create_dataset(tf_valid_ds, batch_size=global_batch_size, shuffling=False)\n",
+    "# hyperparams\n",
+    "batch_size = 4\n",
+    "num_parallel = 2\n",
+    "epochs = 1\n",
+    "model_arch = \"SnapthatT5\"\n",
+    "model_src = \"t5-small\"\n",
+    "learning_rate = 1e-6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Although it doesn't directly solve your problem with TQDM, \n",
+    "    # multiple inheritance is a convenient pattern for Metaflow generally that makes these issues far less painful.\n",
+    "# This TFMixin thing is a parent of the FlowSpec child class.\n",
+    "tf_handler = TFMixin()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The reason to do this is to do iterate quickly in the NB with all the progress bars and iterative Jupyter feel, \n",
+    "    # then once the code runs as you want it is a simple copy-pasta to port over to the FlowSpec and harden the workflow.\n",
+    "    # Wherever `tf_handler.` is used in this cell, replace with `self.` in the FlowSpec tasks.\n",
+    "    # The other minor thing to do during the copy-pasta is use self. in front of hyperparams in the FlowSpec, \n",
+    "        # since they can be set as Metaflow params which you can dynamically set at the flow runtime. \n",
+    "    # See flow_single.py for an example that is implemented.\n",
     "\n",
-    "tensorboard_logpath = tensorboard_logdir + \"/\" + datetime.datetime.now().strftime(\"%Y-%m-%d_%H:%M:%S\")\n",
-    "tensorboard_callback = tf.keras.callbacks.TensorBoard(log_dir=tensorboard_logpath)\n",
+    "tf_train_ds, tf_valid_ds, train_steps, valid_steps = tf_handler.get_data(\n",
+    "    'squad', pct='10', batch_size = batch_size, num_workers=1)\n",
     "\n",
-    "checkpoint_filepath = checkpoint_savedir + \"/T5-{epoch:04d}-{val_loss:.4f}.ckpt\"\n",
-    "checkpoint_callback = tf.keras.callbacks.ModelCheckpoint(\n",
-    "    filepath=checkpoint_filepath,\n",
-    "    mode='min',\n",
-    "    save_best_only=True,\n",
-    ")\n",
+    "callbacks = tf_handler.configure_callbacks(tensorboard_logdir, checkpoint_savedir)\n",
     "\n",
-    "# with strategy.scope():\n",
-    "callbacks = [tensorboard_callback, checkpoint_callback]\n",
-    "metrics = [tf.keras.metrics.SparseTopKCategoricalAccuracy(name='accuracy')]\n",
-    "# learning_rate = CustomSchedule()\n",
-    "learning_rate=1e-6\n",
-    "optimizer = tf.keras.optimizers.Adam(learning_rate)\n",
-    "model = SnapthatT5.from_pretrained(\"t5-small\")\n",
-    "model.compile(optimizer=optimizer, metrics=metrics)\n",
-    "\n",
+    "tuning_set = {'learning_rate': learning_rate}\n",
+    "model = tf_handler.compile_model(model_src = model_src, hyperparams=tuning_set)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let keras do the magic, with progress bars! 🎉 🥳\n",
     "model.fit(\n",
     "    tf_train_ds,\n",
     "    epochs=1,\n",
@@ -349,90 +77,6 @@
     "    validation_steps=valid_steps,\n",
     "    callbacks=callbacks, \n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[(<tf.Tensor: shape=(4, 1), dtype=float32, numpy=\n",
-       "  array([[0.00049844],\n",
-       "         [0.00160483],\n",
-       "         [0.00249983],\n",
-       "         [0.00212634]], dtype=float32)>,\n",
-       "  <tf.Tensor: shape=(4, 1), dtype=int64, numpy=\n",
-       "  array([[1],\n",
-       "         [0],\n",
-       "         [1],\n",
-       "         [1]])>)]"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "def gen():\n",
-    "    (x_train, y_train) = np.random.rand(1), np.random.rand(1) + 0.5\n",
-    "    x_train = x_train / np.float32(255)\n",
-    "    y_train = y_train.astype(np.int64)\n",
-    "    yield x_train, y_train\n",
-    "\n",
-    "dataset = tf.data.Dataset.from_generator(\n",
-    "     gen,\n",
-    "     output_signature=(\n",
-    "         tf.TensorSpec(shape=(1), dtype=tf.float32),\n",
-    "         tf.TensorSpec(shape=(1), dtype=tf.int64)))\n",
-    "\n",
-    "dataset = dataset.repeat().batch(4)\n",
-    "\n",
-    "list(dataset.take(1))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[(<tf.Tensor: shape=(4, 1), dtype=float64, numpy=\n",
-       "  array([[0.00113372],\n",
-       "         [0.00214739],\n",
-       "         [0.00045729],\n",
-       "         [0.0035719 ]])>,\n",
-       "  <tf.Tensor: shape=(4, 1), dtype=int64, numpy=\n",
-       "  array([[0],\n",
-       "         [0],\n",
-       "         [0],\n",
-       "         [1]])>)]"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "(x_train, y_train) = np.random.rand(10, 1), np.random.rand(10, 1) + 0.5\n",
-    "# The `x` arrays are in uint8 and have values in the [0, 255] range.\n",
-    "# You need to convert them to float32 with values in the [0, 1] range.\n",
-    "x_train = x_train / np.float32(255)\n",
-    "y_train = y_train.astype(np.int64)\n",
-    "dataset = (\n",
-    "    tf.data.Dataset.from_tensor_slices((x_train, y_train))\n",
-    "    .shuffle(60000)\n",
-    "    .repeat()\n",
-    "    .batch(4)\n",
-    ")\n",
-    "\n",
-    "list(dataset.take(1))"
    ]
   }
  ],
@@ -452,7 +96,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.10"
   },
   "orig_nbformat": 4
  },


### PR DESCRIPTION
See the comments in the `train.ipynb` that explain the motivation. 

The core idea is that Metaflow is built to run in cloud envs, so often local interaction things like TQDM progress bars used by  `keras.Model(...).fit(..., verbose=1)` won't work well, which is recognized by the [TensorFlow docs](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit): 
> 'auto', 0, 1, or 2. Verbosity mode. 0 = silent, 1 = progress bar, 2 = one line per epoch. 'auto' defaults to 1 for most cases, but 2 when used with ParameterServerStrategy. Note that the progress bar is not particularly useful when logged to a file, so verbose=2 is recommended when not running interactively (eg, in a production environment).

I think our interests here fall under the "production environment" notion mentioned in the docs. 

Long story short there is a small workflow refactor that can hopefully reduce such headaches for you :)   